### PR TITLE
Add py bindings

### DIFF
--- a/samplableset/Cargo.toml
+++ b/samplableset/Cargo.toml
@@ -1,19 +1,25 @@
 [package]
 name = "samplableset-rs"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
+# readme = "README.md"
+# license = { text = "MIT" }
 
 [lib]
 name = "samplableset_rs"
 # This could be adjusted to only compile rlib unless 
-# py_bind or c_bind is enabled using a build.rs script
-# However it would be an extremely hacky build script
+# py_bind or c_bind is enabled using a build.rs script.
+# However, it would be an extremely hacky build script.
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["share_rng"]
+default = ["py_bind"]
 share_rng = []
+c_bind = []
+py_bind = ["dep:pyo3"]
 
 [dependencies]
 rand = "0.9"
 rand_pcg = "0.9"
+
+pyo3 = { version = "0.25.*", features = ["extension-module"], optional = true }

--- a/samplableset/pyproject.toml
+++ b/samplableset/pyproject.toml
@@ -1,0 +1,22 @@
+# project field is automatically populated from Cargo.toml
+# https://www.maturin.rs/metadata#dynamic-metadata
+# [project]
+# name = "samplableset-rs"
+# readme = "README.md"
+# license = { text = "MIT" }
+# version = "0.8.0"
+
+[build-system]
+build-backend = "maturin"
+requires = ["maturin>=1.0,<2.0"]
+
+[tool.maturin]
+profile = "release"
+features = ["py_bind"]
+manifest-path = "Cargo.toml"
+bindings = "pyo3"
+# compatibility = pypi
+
+python-source = "python"
+# renames from samplableset_rs to _samplableset_rs
+# module-name = "samplableset_rs._samplableset_rs"

--- a/samplableset/python/samplableset_rs/__init__.py
+++ b/samplableset/python/samplableset_rs/__init__.py
@@ -1,0 +1,3 @@
+from .samplableset_rs import SamplableSet
+
+__all__ = ["SamplableSet"]

--- a/samplableset/src/lib.rs
+++ b/samplableset/src/lib.rs
@@ -35,9 +35,22 @@
 //! If $W$ is bounded in your application, operations are effectively
 //! $\mathcal{O}(1)$ on average.
 
+// Only compiles the module if py_bind feature is enabled
+#[cfg(feature = "py_bind")]
+mod py_bind;
+#[cfg(feature = "py_bind")]
+use pyo3::{pymodule, types::PyModule, Bound, PyResult};
 
 mod binary_tree;
 mod hash_propensity;
 pub mod samplable_set;
 
 pub use samplable_set::SamplableSet;
+
+#[cfg(feature = "py_bind")]
+#[pymodule]
+fn samplableset_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    py_bind::register_py(m)?;
+    
+    Ok(())
+}

--- a/samplableset/src/py_bind.rs
+++ b/samplableset/src/py_bind.rs
@@ -1,0 +1,211 @@
+// MIT License
+//
+// Copyright (c) 2025 Jai Veilleux
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use pyo3::prelude::*;
+use pyo3::exceptions::{PyKeyError, PyValueError};
+use pyo3::types::PyAny;
+use pyo3::types::PyAnyMethods; // This import brings the extract method into scope
+use std::fmt;
+
+use crate::samplable_set::{SamplableSet, SSetError};
+
+impl<K: fmt::Debug> From<SSetError<K>> for PyErr {
+    fn from(err: SSetError<K>) -> Self {        
+        match err {
+            SSetError::EmptySet => PyErr::new::<PyValueError, _>("The set is empty."),
+            SSetError::InconsistentState(msg) => {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(msg)
+            }
+            SSetError::KeyNotFound(key) => {
+                PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!("Key not found in the set: {:?}", key))
+            }
+            SSetError::WeightOutOfRange { w, min, max } => {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Weight {} is out of range [{}, {}]",
+                    w, min, max
+                ))
+            }
+        }
+    }
+}
+
+// Declare all supported types in one pass
+macro_rules! sset_variants {
+    ( $( ($ty:ty, $Variant:ident, $kind_str:literal) ),+ $(,)?) => {
+        
+        enum Inner {
+            $( $Variant(SamplableSet<$ty>), )+
+        }
+
+        impl Inner {
+            fn new(kind: &str, w_min: f64, w_max: f64) -> PyResult<Self> {
+                match kind {
+                    // TODO replace expect with proper error variant
+                    $( $kind_str => Ok(
+                        Inner::$Variant(
+                            SamplableSet::<$ty>
+                                ::new(w_min, w_max)
+                                .map_err::<PyErr, _>(Into::into)?
+                        )), )+
+                    _ => Err(PyErr::new::<PyValueError, _>(format!("Unsupported kind: {kind}, expected one of: {}", 
+                                                       [$( $kind_str ),+].join(", ")))),
+                }
+            }
+
+            fn size(&self) -> usize {
+                match self { $( Inner::$Variant(s) => s.size(), )+ }
+            }
+
+            fn empty(&self) -> bool {
+                match self { $( Inner::$Variant(s) => s.empty(), )+ }
+            }
+
+            fn exists(&self, key: &Bound<'_, PyAny>) -> PyResult<bool> {
+                Ok(match self {
+                    $( Inner::$Variant(s) => s.exists(&key.extract::<$ty>()?), )+
+                })
+            }
+
+            fn total_weight(&self) -> f64 {
+                match self { $( Inner::$Variant(s) => s.total_weight(), )+ }
+            }
+
+            fn get_weight(&self, key: &Bound<'_, PyAny>) -> PyResult<f64> {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        let k: $ty = key.extract()?;
+                        if !s.exists(&k) {
+                            return Err(PyErr::new::<PyKeyError, _>(format!("Key not found: {:?}", k)));
+                        } else {
+                            s.get_weight(&k).map_err(Into::into)
+                        }
+                    } )+
+                }
+            }
+
+            fn insert(&mut self, key: &Bound<'_, PyAny>, weight: f64) -> PyResult<bool> {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        let k: $ty = key.extract()?;
+                        s.insert(&k, weight).map_err(Into::into)
+                    } )+
+                }
+            }
+
+            fn set_weight(&mut self, key: &Bound<'_, PyAny>, weight: f64) -> PyResult<()> {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        let k: $ty = key.extract()?;
+                        s.set_weight(&k, weight).map_err(Into::into)
+                    } )+
+                }
+            }
+
+            fn erase(&mut self, key: &Bound<'_, PyAny>) -> PyResult<bool> {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        let k: $ty = key.extract()?;
+                        Ok(s.erase(&k))
+                    } )+
+                }
+            }
+
+            fn seed(&mut self, seed: u64) {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        s.seed(seed);
+                    } )+
+                }
+            }
+
+            fn sample_py<'py>(&mut self, py: Python<'py>) -> PyResult<(PyObject, f64)> {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        match s.sample()? {
+                            (k, w) => {
+                                let obj: PyObject = k.into_pyobject(py)
+                                    .map_err(|e| PyErr::new::<PyValueError, _>(
+                                        format!("Failed to convert key to PyObject: {}", e)))?.unbind().into();
+                                Ok((obj, w))
+                            },
+                        }
+                    } ),+
+                }
+            }            
+
+            // fn sample_ext_rng<'py>(&mut self, py: Python<'py>) -> PyResult<(PyObject, f64)> {
+            //     match self {
+            //         // $( Inner::$Variant(s) => s.sample_ext_rng().map(|(k, w)| (k.into_pyobject(py), w)) )+
+            //     }
+            // }
+
+            fn clear(&mut self) {
+                match self { $( Inner::$Variant(s) => s.clear(), )+ }
+            }
+
+            // deterministic iterator -> python list
+            fn snapshot_items<'py>(&self, py: Python<'py>) -> PyResult<Vec<(PyObject, f64)>> {
+                match self {
+                    $( Inner::$Variant(s) => {
+                        (&*s)
+                            .into_iter()
+                            .map(|(k, w)| {
+                                // k is &T; clone/copy then convert
+                                let obj: PyObject = k.clone().into_pyobject(py)?.unbind().into();
+                                Ok::<(PyObject, f64), PyErr>((obj, w))
+                            })
+                            .collect::<PyResult<Vec<_>>>()
+                    } ),+
+                }
+            }
+
+            #[inline]
+            fn kind_str(&self) -> &'static str {
+                match self { $( Inner::$Variant(_) => $kind_str, )+ }
+            }
+        }
+    };
+}
+
+// Variants:
+// Int
+// (Int, Int)
+// (Int, Int, Int)
+// String
+// (String, String)
+// (String, String, String)
+sset_variants! {
+    (u64, U64, "u64"),
+    ((u64, u64), Tuple2Int, "tuple2int"),
+    ((u64, u64, u64), Tuple3Int, "tuple3int"),
+    (String, Str, "str"),
+    ((String, String), Tuple2Str, "tuple2str"),
+    ((String, String, String), Tuple3Str, "tuple3str"),
+}
+
+// #[pyclass(
+//     module = "samplableset",
+//     name = "SamplableSet"
+// )]
+// pub struct PySamplableSet {
+//     inner: Inner,
+// }

--- a/samplableset/src/samplable_set.rs
+++ b/samplableset/src/samplable_set.rs
@@ -42,7 +42,6 @@ type SSetResult<T, K> = Result<T, SSetError<K>>;
 
 type PropensityGroup<T> = Vec<(T, f64)>;
 
-// TODO add option for below
 // For consistency with original C++ implementation
 // All instances share the same rng stream (per thread)
 #[cfg(feature = "share_rng")]
@@ -344,11 +343,16 @@ where
         return true
     }
 
-    // TODO expose publicly?
-    #[cfg(not(feature = "share_rng"))]
-    #[allow(dead_code)]
+    /// Seeds the internal RNG given a u64 value
+    /// 
+    /// If the `share_rng` feature is enabled this 
+    /// will update the RNG for all instances of SamplableSet
     pub fn seed(&mut self, seed: u64) {
-        self.rng_ = RNGType::seed_from_u64(seed);
+        #[cfg(not(feature = "share_rng"))]
+        { self.rng_ = RNGType::seed_from_u64(seed); }
+        
+        #[cfg(feature = "share_rng")]
+        seed_static_gen(seed);
     }
 
     /// Draw one `(element, weight)` proportional to weight (with replacement).


### PR DESCRIPTION
Optional feature `py_bind` is added and brings the dependency `pyo3` into the build process.

Implements wrapper structs for concrete types of `SamplableSet` in `py_bind.rs`

Currently supported variants:

```
Int
(Int, Int)
(Int, Int, Int)
String
(String, String)
(String, String, String)
```

These structs are further wrapped in an outer struct so that use in python space only requires passing it type information when creating an instance of `SamplableSet`

Resolves #3 

`pyproject.toml` and `__init__.py` are added to support building a python package using `maturin`. This build pipeline will need to be documented, but I want to look into creating a unified build process.

Resolves #5