### PR TITLE
Make thread safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+samplableset-py/
+target/
+__pycache__/
+
+*.pyd
+# .gitignore
+# This is a library, so we don't want to dictate dependency versions
+Cargo.lock

--- a/samplableset/Cargo.toml
+++ b/samplableset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samplableset-rs"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 # readme = "README.md"
 # license = { text = "MIT" }

--- a/samplableset/src/binary_tree.rs
+++ b/samplableset/src/binary_tree.rs
@@ -237,7 +237,8 @@ impl BinaryTree {
                 let n = self.cur_node_.as_ref().expect(
                     "BinaryTree invariant violated: cannot get leaf index: current_node_ is None",
                 );
-                let key = Arc::as_ptr(n) as usize; //as *const RwLock<BTreeNode> as usize;
+                // Use the raw pointer as a UID for the node. Safe because there is no dereferencing.
+                let key = Arc::as_ptr(n) as usize;
                 *self.leaves_idx_map_.get(&key).expect(
                     "BinaryTree invariant violated: current_node_ is not a leaf (no leaf index)",
                 )
@@ -405,7 +406,7 @@ impl BinaryTree {
 
             Some(child)
         } else {
-            let key = Arc::as_ptr(&parent) as *const _ as usize;
+            let key = Arc::as_ptr(&parent) as usize;
             if !self.leaves_idx_map_.contains_key(&key) {
                 let idx = self.leaves_.len() as LeafIdx;
                 self.leaves_idx_map_.insert(key, idx);

--- a/samplableset/src/binary_tree.rs
+++ b/samplableset/src/binary_tree.rs
@@ -21,10 +21,11 @@
 // SOFTWARE.
 
 use std::{
-    cell::RefCell,
+    // cell::RefCell,
     collections::HashMap,
     ops::Deref,
-    rc::{Rc, Weak},
+    //rc::{Rc, Weak}, 
+    sync::{Arc, Weak, RwLock},
 };
 
 type LeafIdx = usize;
@@ -32,12 +33,12 @@ type LeafIdx = usize;
 #[doc(hidden)]
 /// A strong reference to a `BTreeNode`.
 #[derive(Debug, Clone)]
-pub(crate) struct NodeRef(Rc<RefCell<BTreeNode>>);
+pub(crate) struct NodeRef(Arc<RwLock<BTreeNode>>);
 
 #[doc(hidden)]
 /// A weak reference to a `BTreeNode`.
 #[derive(Debug)]
-pub(crate) struct WeakNodeRef(Weak<RefCell<BTreeNode>>);
+pub(crate) struct WeakNodeRef(Weak<RwLock<BTreeNode>>);
 
 // ==============================================
 
@@ -47,7 +48,7 @@ impl NodeRef {
     /// 
     /// Acts like a `Rc<RefCell<BTreeNode>>`
     pub(crate) fn new(node: BTreeNode) -> Self {
-        NodeRef(Rc::new(RefCell::new(node)))
+        NodeRef(Arc::new(RwLock::new(node)))
     }
 
     #[doc(hidden)]
@@ -55,12 +56,12 @@ impl NodeRef {
     /// 
     /// NodeRef -> WeakNodeRef
     pub(crate) fn downgrade(&self) -> WeakNodeRef {
-        WeakNodeRef(Rc::downgrade(&self))
+        WeakNodeRef(Arc::downgrade(self))
     }
 }
 
 impl Deref for NodeRef {
-    type Target = Rc<RefCell<BTreeNode>>;
+    type Target = Arc<RwLock<BTreeNode>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -88,7 +89,7 @@ impl WeakNodeRef {
 }
 
 impl Deref for WeakNodeRef {
-    type Target = Weak<RefCell<BTreeNode>>;
+    type Target = Weak<RwLock<BTreeNode>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -148,7 +149,7 @@ impl BinaryTree {
     pub(crate) fn is_root(&self) -> bool {
         self.cur_node_
             .as_ref()
-            .map(|n| n.borrow().parent.upgrade().is_none())
+            .map(|n| n.read().unwrap().parent.upgrade().is_none())
             .expect("BinaryTree invariant violated: cannot check root: current_node_ is None")
     }
 
@@ -158,7 +159,7 @@ impl BinaryTree {
         self.cur_node_
             .as_ref()
             .map(|n| {
-                let nb = n.borrow();
+                let nb = n.read().unwrap();
                 nb.left.is_none() && nb.right.is_none()
             })
             .expect("BinaryTree invariant violated: cannot check leaf: current node is None")
@@ -171,7 +172,7 @@ impl BinaryTree {
     pub(crate) fn get_val(&self) -> f64 {
         self.cur_node_
             .as_ref()
-            .map(|n| n.borrow().val)
+            .map(|n| n.read().unwrap().val)
             .expect("BinaryTree invariant violated: cannot get val: current node is None")
     }
 
@@ -180,10 +181,13 @@ impl BinaryTree {
     /// 
     /// This is guaranteed to always return Something
     pub(crate) fn get_left_val(&self) -> f64 {
-        self.cur_node_
-            .as_ref()
-            .and_then(|n| n.borrow().left.as_ref().map(|l| l.borrow().val))
-            .expect("BinaryTree invariant violated: left child is missing")
+        let left = {
+            let cur = self.cur_node_.as_ref()
+                .expect("BinaryTree invariant violated: cannot get left val: current node  is None");
+            let c = cur.read().unwrap();
+            c.left.clone().expect("BinaryTree invariant violated: left child is missing")
+        };
+        left.read().unwrap().val
     }
 
     #[doc(hidden)]
@@ -193,10 +197,13 @@ impl BinaryTree {
     /// But also guaranteed to always return Something
     #[allow(dead_code)]
     pub(crate) fn get_right_val(&self) -> f64 {
-        self.cur_node_
-            .as_ref()
-            .and_then(|n| n.borrow().right.as_ref().map(|r| r.borrow().val))
-            .expect("BinaryTree invariant violated: right child is missing")
+        let right = {
+            let cur = self.cur_node_.as_ref()
+                .expect("BinaryTree invariant violated: cannot get right val: current node is None");
+            let c = cur.read().unwrap();
+            c.right.clone().expect("BinaryTree invariant violated: right child is missing")
+        };
+        right.read().unwrap().val
     }
 
     #[doc(hidden)]
@@ -223,7 +230,7 @@ impl BinaryTree {
             None => {
                 let n = self.cur_node_.as_ref()
                     .expect("BinaryTree invariant violated: cannot get leaf index: current_node_ is None");
-                let key = Rc::as_ptr(&n) as *const RefCell<BTreeNode> as usize;
+                let key = Arc::as_ptr(n) as usize; //as *const RwLock<BTreeNode> as usize;
                 *self
                     .leaves_idx_map_
                     .get(&key)
@@ -241,28 +248,24 @@ impl BinaryTree {
     #[doc(hidden)]
     /// Current node becomes its left child
     pub(crate) fn move_down_left(&mut self) {
-        let next = self
-            .cur_node_
-            .as_ref()
-            .expect("BinaryTree invariant violated: cannot move down left: current_node_ is None")
-            .borrow()
-            .left
-            .clone()
-            .expect("BinaryTree invariant violated: cannot move down left: no left child");
+        let next = {
+            let cur = self.cur_node_.as_ref().expect("BinaryTree invariant violated: cannot move down left: current_node_ is None");
+            let guard = cur.read().unwrap();
+            guard.left.clone().expect("BinaryTree invariant violated: cannot move down left: no left child")
+        };
         self.cur_node_ = Some(next);
     }
 
     #[doc(hidden)]
     /// Current node becomes its right child
     pub(crate) fn move_down_right(&mut self) {
-        let next = self
-            .cur_node_
-            .as_ref()
-            .expect("BinaryTree invariant violated: cannot move down right: current_node_ is None")
-            .borrow()
-            .right
-            .clone()
-            .expect("BinaryTree invariant violated: cannot move down right: no right child");
+        let next = {
+            let cur = self.cur_node_.as_ref()
+                .expect("BinaryTree invariant violated: cannot move down right: current_node_ is None");
+            let guard = cur.read().unwrap();
+            guard.right.clone()
+                .expect("BinaryTree invariant violated: cannot move down right: no right child")
+        };
         self.cur_node_ = Some(next);
     }
 
@@ -270,13 +273,11 @@ impl BinaryTree {
     /// Current node becomes its parent
     pub(crate) fn move_up(&mut self) {
         let next = {
-            let cur = self.cur_node_.as_ref().expect("BinaryTree invariant violated: cannot move up: current_node_ is None");
-            let parent_rc = cur
-                .borrow()
-                .parent
-                .upgrade()
-                .expect("BinaryTree invariant violated: cannot move up: no parent");
-            parent_rc
+            let cur = self.cur_node_.as_ref()
+                .expect("BinaryTree invariant violated: cannot move up: current_node_ is None");
+            let guard = cur.read().unwrap();
+            guard.parent.upgrade()
+                .expect("BinaryTree invariant violated: cannot move up: no parent")
         };
         self.cur_node_ = Some(next);
     }
@@ -318,7 +319,7 @@ impl BinaryTree {
                 .cur_node_
                 .as_ref()
                 .expect("current node is None in _update_helper");
-            cur.borrow_mut().val += variation;
+            cur.write().unwrap().val += variation;
         }
 
         // walk up to the root, adding at each ancestor
@@ -328,7 +329,7 @@ impl BinaryTree {
                 .cur_node_
                 .as_ref()
                 .expect("current node is None after move_up");
-            cur.borrow_mut().val += variation;
+            cur.write().unwrap().val += variation;
         }
     }
 
@@ -341,7 +342,7 @@ impl BinaryTree {
         self.cur_node_
             .as_ref()
             .expect("current node is None in update_zero")
-            .borrow_mut()
+            .write().unwrap()
             .val = 0.0;
         while !self.is_root() {
             self.move_up();
@@ -349,7 +350,7 @@ impl BinaryTree {
                 .cur_node_
                 .as_ref()
                 .expect("current node is None after move_up in update_zero");
-            cur.borrow_mut().val = 0.0;
+            cur.write().unwrap().val = 0.0;
         }
     }
 
@@ -378,14 +379,14 @@ impl BinaryTree {
             let right = self.branch(child.clone(), node_idx * 2 + 2, n_nodes);
 
             {
-                let mut cb = child.borrow_mut();
+                let mut cb = child.write().unwrap();
                 cb.left = left;
                 cb.right = right;
             }
 
             Some(child)
         } else {
-            let key = Rc::as_ptr(&parent) as *const _ as usize;
+            let key = Arc::as_ptr(&parent) as *const _ as usize;
             if !self.leaves_idx_map_.contains_key(&key) {
                 let idx = self.leaves_.len() as LeafIdx;
                 self.leaves_idx_map_.insert(key, idx);
@@ -402,7 +403,7 @@ impl<T: Into<u32>> From<T> for BinaryTree {
         let n_leaves: u32 = n_leaves.into();
         // n_leaves guaranteed to be > 0 by SamplableSet::new()
         debug_assert!(
-            !(n_leaves < 1),
+            n_leaves >= 1,
             "BinaryTree must have at least one leaf"
         );
 
@@ -427,7 +428,7 @@ impl<T: Into<u32>> From<T> for BinaryTree {
         let right = tree.branch(root.clone(), 2, n_nodes);
 
         {
-            let mut rb = root.0.borrow_mut();
+            let mut rb = root.write().unwrap();
             rb.left  = left;
             rb.right = right;
         }
@@ -462,13 +463,13 @@ impl Clone for BinaryTree {
         let right = BinaryTree::branch(&mut out, root.clone(), 2, n_nodes);
 
         {
-            let mut rb = root.borrow_mut();
+            let mut rb = root.write().unwrap();
             rb.left = left;
             rb.right = right;
         }
 
         for (leaf_idx, src_leaf) in self.leaves_.iter().enumerate() {
-            let v = src_leaf.borrow().val;
+            let v = src_leaf.read().unwrap().val;
             BinaryTree::update_value(&mut out, v, Some(leaf_idx as LeafIdx));
         }
 
@@ -569,13 +570,13 @@ mod tests {
     fn test_navigation_moves() {
         let mut bt = BinaryTree::from(4u32);
         bt.reset_cur_node();
-        let root_ptr = Rc::as_ptr(bt.root_.as_ref().unwrap()) as usize;
+        let root_ptr = Arc::as_ptr(bt.root_.as_ref().unwrap()) as usize;
         bt.move_down_left();
         assert!(!bt.is_root());
         bt.move_up();
         // back at root
         assert_eq!(
-            Rc::as_ptr(bt.cur_node_.as_ref().unwrap()) as usize,
+            Arc::as_ptr(bt.cur_node_.as_ref().unwrap()) as usize,
             root_ptr
         );
         bt.move_down_right();
@@ -614,8 +615,8 @@ mod tests {
         let target_leaf = bt.leaves_[2].clone();
         bt.move_to(target_leaf.clone());
         assert!(bt.is_leaf());
-        let cur_ptr = Rc::as_ptr(bt.cur_node_.as_ref().unwrap()) as usize;
-        let tgt_ptr = Rc::as_ptr(&target_leaf) as usize;
+        let cur_ptr = Arc::as_ptr(bt.cur_node_.as_ref().unwrap()) as usize;
+        let tgt_ptr = Arc::as_ptr(&target_leaf) as usize;
         assert_eq!(cur_ptr, tgt_ptr);
     }
 

--- a/samplableset/src/binary_tree.rs
+++ b/samplableset/src/binary_tree.rs
@@ -46,7 +46,7 @@ impl NodeRef {
     #[doc(hidden)]
     /// Creates a new `NodeRef`.
     ///
-    /// Acts like a `Rc<RefCell<BTreeNode>>`
+    /// Acts like an `Arc<RwLock<BTreeNode>>`
     pub(crate) fn new(node: BTreeNode) -> Self {
         NodeRef(Arc::new(RwLock::new(node)))
     }
@@ -74,7 +74,7 @@ impl WeakNodeRef {
     #[doc(hidden)]
     /// Creates a new, empty `WeakNodeRef`.
     ///
-    /// Acts like a `Weak<RefCell<BTreeNode>>`
+    /// Acts like a `Weak<RwLock<BTreeNode>>`
     pub(crate) fn new() -> Self {
         WeakNodeRef(Weak::new())
     }

--- a/samplableset/src/binary_tree.rs
+++ b/samplableset/src/binary_tree.rs
@@ -24,8 +24,8 @@ use std::{
     // cell::RefCell,
     collections::HashMap,
     ops::Deref,
-    //rc::{Rc, Weak}, 
-    sync::{Arc, Weak, RwLock},
+    //rc::{Rc, Weak},
+    sync::{Arc, RwLock, Weak},
 };
 
 type LeafIdx = usize;
@@ -45,7 +45,7 @@ pub(crate) struct WeakNodeRef(Weak<RwLock<BTreeNode>>);
 impl NodeRef {
     #[doc(hidden)]
     /// Creates a new `NodeRef`.
-    /// 
+    ///
     /// Acts like a `Rc<RefCell<BTreeNode>>`
     pub(crate) fn new(node: BTreeNode) -> Self {
         NodeRef(Arc::new(RwLock::new(node)))
@@ -53,7 +53,7 @@ impl NodeRef {
 
     #[doc(hidden)]
     /// Downgrades the strong reference to a weak reference.
-    /// 
+    ///
     /// NodeRef -> WeakNodeRef
     pub(crate) fn downgrade(&self) -> WeakNodeRef {
         WeakNodeRef(Arc::downgrade(self))
@@ -73,7 +73,7 @@ impl Deref for NodeRef {
 impl WeakNodeRef {
     #[doc(hidden)]
     /// Creates a new, empty `WeakNodeRef`.
-    /// 
+    ///
     /// Acts like a `Weak<RefCell<BTreeNode>>`
     pub(crate) fn new() -> Self {
         WeakNodeRef(Weak::new())
@@ -81,7 +81,7 @@ impl WeakNodeRef {
 
     #[doc(hidden)]
     /// Upgrades the weak reference to a strong reference, if the node is still alive.
-    /// 
+    ///
     /// WeakNodeRef -> NodeRef
     pub(crate) fn upgrade(&self) -> Option<NodeRef> {
         self.0.upgrade().map(NodeRef)
@@ -167,7 +167,7 @@ impl BinaryTree {
 
     #[doc(hidden)]
     /// Returns the value of the current node.
-    /// 
+    ///
     /// Guaranteed to always return Something
     pub(crate) fn get_val(&self) -> f64 {
         self.cur_node_
@@ -178,30 +178,36 @@ impl BinaryTree {
 
     #[doc(hidden)]
     /// Returns the value of the left child.
-    /// 
+    ///
     /// This is guaranteed to always return Something
     pub(crate) fn get_left_val(&self) -> f64 {
         let left = {
-            let cur = self.cur_node_.as_ref()
-                .expect("BinaryTree invariant violated: cannot get left val: current node  is None");
+            let cur = self.cur_node_.as_ref().expect(
+                "BinaryTree invariant violated: cannot get left val: current node  is None",
+            );
             let c = cur.read().unwrap();
-            c.left.clone().expect("BinaryTree invariant violated: left child is missing")
+            c.left
+                .clone()
+                .expect("BinaryTree invariant violated: left child is missing")
         };
         left.read().unwrap().val
     }
 
     #[doc(hidden)]
     /// Returns the value of the right child.
-    /// 
+    ///
     /// Not used in current SamplableSet implementation
     /// But also guaranteed to always return Something
     #[allow(dead_code)]
     pub(crate) fn get_right_val(&self) -> f64 {
         let right = {
-            let cur = self.cur_node_.as_ref()
-                .expect("BinaryTree invariant violated: cannot get right val: current node is None");
+            let cur = self.cur_node_.as_ref().expect(
+                "BinaryTree invariant violated: cannot get right val: current node is None",
+            );
             let c = cur.read().unwrap();
-            c.right.clone().expect("BinaryTree invariant violated: right child is missing")
+            c.right
+                .clone()
+                .expect("BinaryTree invariant violated: right child is missing")
         };
         right.read().unwrap().val
     }
@@ -228,13 +234,13 @@ impl BinaryTree {
                 chosen_leaf
             }
             None => {
-                let n = self.cur_node_.as_ref()
-                    .expect("BinaryTree invariant violated: cannot get leaf index: current_node_ is None");
+                let n = self.cur_node_.as_ref().expect(
+                    "BinaryTree invariant violated: cannot get leaf index: current_node_ is None",
+                );
                 let key = Arc::as_ptr(n) as usize; //as *const RwLock<BTreeNode> as usize;
-                *self
-                    .leaves_idx_map_
-                    .get(&key)
-                    .expect("BinaryTree invariant violated: current_node_ is not a leaf (no leaf index)")
+                *self.leaves_idx_map_.get(&key).expect(
+                    "BinaryTree invariant violated: current_node_ is not a leaf (no leaf index)",
+                )
             }
         }
     }
@@ -249,9 +255,14 @@ impl BinaryTree {
     /// Current node becomes its left child
     pub(crate) fn move_down_left(&mut self) {
         let next = {
-            let cur = self.cur_node_.as_ref().expect("BinaryTree invariant violated: cannot move down left: current_node_ is None");
+            let cur = self.cur_node_.as_ref().expect(
+                "BinaryTree invariant violated: cannot move down left: current_node_ is None",
+            );
             let guard = cur.read().unwrap();
-            guard.left.clone().expect("BinaryTree invariant violated: cannot move down left: no left child")
+            guard
+                .left
+                .clone()
+                .expect("BinaryTree invariant violated: cannot move down left: no left child")
         };
         self.cur_node_ = Some(next);
     }
@@ -260,10 +271,13 @@ impl BinaryTree {
     /// Current node becomes its right child
     pub(crate) fn move_down_right(&mut self) {
         let next = {
-            let cur = self.cur_node_.as_ref()
-                .expect("BinaryTree invariant violated: cannot move down right: current_node_ is None");
+            let cur = self.cur_node_.as_ref().expect(
+                "BinaryTree invariant violated: cannot move down right: current_node_ is None",
+            );
             let guard = cur.read().unwrap();
-            guard.right.clone()
+            guard
+                .right
+                .clone()
                 .expect("BinaryTree invariant violated: cannot move down right: no right child")
         };
         self.cur_node_ = Some(next);
@@ -273,10 +287,14 @@ impl BinaryTree {
     /// Current node becomes its parent
     pub(crate) fn move_up(&mut self) {
         let next = {
-            let cur = self.cur_node_.as_ref()
+            let cur = self
+                .cur_node_
+                .as_ref()
                 .expect("BinaryTree invariant violated: cannot move up: current_node_ is None");
             let guard = cur.read().unwrap();
-            guard.parent.upgrade()
+            guard
+                .parent
+                .upgrade()
                 .expect("BinaryTree invariant violated: cannot move up: no parent")
         };
         self.cur_node_ = Some(next);
@@ -293,11 +311,9 @@ impl BinaryTree {
     pub(crate) fn update_value(&mut self, variation: f64, idx: Option<LeafIdx>) {
         match idx {
             Some(leaf_idx) => {
-                let node = self
-                    .leaves_
-                    .get(leaf_idx)
-                    .cloned()
-                    .expect("BinaryTree invariant violated: Cannot update value: invalid leaf index");
+                let node = self.leaves_.get(leaf_idx).cloned().expect(
+                    "BinaryTree invariant violated: Cannot update value: invalid leaf index",
+                );
                 self.cur_node_ = Some(node);
                 self._update_helper(variation);
             }
@@ -305,7 +321,9 @@ impl BinaryTree {
                 if self.is_leaf() {
                     self._update_helper(variation);
                 } else {
-                    println!("BinaryTree invariant violated: Cannot update value: current node is not a leaf");
+                    println!(
+                        "BinaryTree invariant violated: Cannot update value: current node is not a leaf"
+                    );
                 }
             }
         }
@@ -342,7 +360,8 @@ impl BinaryTree {
         self.cur_node_
             .as_ref()
             .expect("current node is None in update_zero")
-            .write().unwrap()
+            .write()
+            .unwrap()
             .val = 0.0;
         while !self.is_root() {
             self.move_up();
@@ -402,10 +421,7 @@ impl<T: Into<u32>> From<T> for BinaryTree {
     fn from(n_leaves: T) -> Self {
         let n_leaves: u32 = n_leaves.into();
         // n_leaves guaranteed to be > 0 by SamplableSet::new()
-        debug_assert!(
-            n_leaves >= 1,
-            "BinaryTree must have at least one leaf"
-        );
+        debug_assert!(n_leaves >= 1, "BinaryTree must have at least one leaf");
 
         // let n_leaves = n_leaves * 2 - 1;
 
@@ -424,12 +440,12 @@ impl<T: Into<u32>> From<T> for BinaryTree {
             .expect("Overflow calculating number of nodes");
 
         // Build subtrees (None when n_leaves == 1)
-        let left  = tree.branch(root.clone(), 1, n_nodes);
+        let left = tree.branch(root.clone(), 1, n_nodes);
         let right = tree.branch(root.clone(), 2, n_nodes);
 
         {
             let mut rb = root.write().unwrap();
-            rb.left  = left;
+            rb.left = left;
             rb.right = right;
         }
 

--- a/samplableset/src/hash_propensity.rs
+++ b/samplableset/src/hash_propensity.rs
@@ -32,9 +32,9 @@ pub(crate) struct HashPropensity {
 impl HashPropensity {
     #[doc(hidden)]
     /// Creates a new `HashPropensity`.
-    /// 
+    ///
     /// Valid conditions for creating a new HashPropensity are enforced by SamplableSet
-    /// 
+    ///
     /// - `propensity_min` must be positive and less than infinity
     /// - `propensity_max` must be finite and greater than `propensity_min`
     pub(crate) fn new(propensity_min: f64, propensity_max: f64) -> Self {
@@ -47,7 +47,7 @@ impl HashPropensity {
             "Propensity max must be finite and greater than min"
         );
 
-        let is_pow_two = is_pow_two_f64(propensity_max / propensity_min);        
+        let is_pow_two = is_pow_two_f64(propensity_max / propensity_min);
 
         HashPropensity {
             propensity_min_: propensity_min,
@@ -58,7 +58,7 @@ impl HashPropensity {
 
     #[doc(hidden)]
     /// Returns the index of the given propensity.
-    /// 
+    ///
     /// Valid conditions for using this function are enforced by SamplableSet
     ///
     /// - `propensity` must be finite and greater than zero
@@ -95,7 +95,7 @@ impl HashPropensity {
 /// mant = bits & ((1u64 << 52) - 1);
 /// exp != 0 && exp != 0x7ff && mant == 0
 /// ```
-/// 
+///
 /// Equivalent to
 /// ```ignore
 /// f64::floor(f64::log2(
@@ -108,7 +108,7 @@ impl HashPropensity {
 fn is_pow_two_f64(x: f64) -> bool {
     if !(x.is_finite()) || x <= 0.0 {
         return false;
-    }    
+    }
     (x.to_bits() & ((1u64 << 52) - 1)) == 0
 }
 

--- a/samplableset/src/lib.rs
+++ b/samplableset/src/lib.rs
@@ -39,7 +39,7 @@
 #[cfg(feature = "py_bind")]
 mod py_bind;
 #[cfg(feature = "py_bind")]
-use pyo3::{pymodule, types::PyModule, Bound, PyResult};
+use pyo3::{Bound, PyResult, pymodule, types::PyModule};
 
 mod binary_tree;
 mod hash_propensity;
@@ -51,6 +51,6 @@ pub use samplable_set::SamplableSet;
 #[pymodule]
 fn samplableset_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     py_bind::register_py(m)?;
-    
+
     Ok(())
 }

--- a/samplableset/src/py_bind.rs
+++ b/samplableset/src/py_bind.rs
@@ -214,7 +214,7 @@ sset_variants! {
     // as well as a refactor of the static RNG logic.
     // A potential solution to the RNG logic could involve creating a singleton 
     // instance using something like OnceLock.
-    unsendable,
+    // unsendable,
 )]
 struct PySamplableSet {
     inner: Inner,

--- a/samplableset/src/samplable_set.rs
+++ b/samplableset/src/samplable_set.rs
@@ -715,11 +715,6 @@ mod global_rng {
             f(&mut slot.1)
         })
     }
-
-    // #[inline]
-    // pub fn global_random_range(range: std::ops::Range<f64>) -> f64 {
-    //     with_rng(|rng| rng.random_range(range))
-    // }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves #13 

This PR changes the pointers inside of the `BinaryTree` to be of type `Arc<RwLock<BTreeNode>>` instead of type  `Rc<RefCell<BTreeNode>>` so that `SamplableSet` becomes `Send`able.

`RwLock` allows for multiple readers and only one writer at a time. Since most of the use is from sampling with replacement, I think this makes sense. If contention turns out to be a problem (i.e. someone has a use case with high writes, high reads and writes, etc.) this can be revisited.

This also required updating the static RNG to track an `epoch`. Each time a `SamplableSet` is re-seeded with the `share_rng` feature enabled, the `GLOBAL_SEED` and `EPOCH` are updated. When a `SamplableSet` then goes to sample, if there is an `EPOCH` mismatch it first re-seeds its thread-local RNG.